### PR TITLE
feat: add extra array as generated structure

### DIFF
--- a/src/Processor/DefaultProcessor.php
+++ b/src/Processor/DefaultProcessor.php
@@ -5,13 +5,15 @@ namespace JorisRos\LibraryProductExporter\Processor;
 use JorisRos\LibraryProductExporter\Connector\Configuration;
 use JorisRos\LibraryProductExporter\Transform\DefaultTransform;
 use JorisRos\LibraryProductExporter\Transform\TransformInterface;
+use JorisRos\LibraryProductExporter\Utils\ValuePlacer;
 
 class DefaultProcessor implements ProcessorInterface
 {
     private array $result = [];
     public function __construct(
         readonly private array $configuration,
-        readonly private array $transformers
+        readonly private array $transformers,
+        private ValuePlacer $valuePlacer = new ValuePlacer()
     ) {
     }
 
@@ -37,7 +39,7 @@ class DefaultProcessor implements ProcessorInterface
 
     private function addValueToResult(TransformInterface $transform, string $field): void
     {
-        $array = $this->stringToMultiArrayWithValue($field, $transform->getValue());
+        $array = $this->valuePlacer->stringToMultiArrayWithValue($field, $transform->getValue());
         $this->result = array_merge_recursive($this->result, $array);
     }
 
@@ -52,22 +54,5 @@ class DefaultProcessor implements ProcessorInterface
         }
 
         return $acceptedTransformers;
-    }
-
-    private function stringToMultiArrayWithValue($string, $value): array
-    {
-        $levels = explode('.', $string);
-        $result = [];
-        $current = &$result;
-
-        foreach ($levels as $level) {
-            $current[$level] = [];
-            $current = &$current[$level];
-        }
-
-        // Add the value to the deepest level
-        $current = $value;
-
-        return $result;
     }
 }

--- a/src/Utils/ValuePlacer.php
+++ b/src/Utils/ValuePlacer.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace JorisRos\LibraryProductExporter\Utils;
+
+class ValuePlacer
+{
+    public function __construct(private string $seperator = '.')
+    {
+    }
+    public function stringToMultiArrayWithValue($string, $value): array
+    {
+        $levels = explode($this->seperator, $string);
+        $result = [];
+        $current = &$result;
+
+        foreach ($levels as $level) {
+            if (str_ends_with($level, '[]')) {
+                $key = substr($level, 0, -2);
+                $current[$key] = [];
+                $current[$key][] = [];
+                $current = &$current[$key][0];
+            } else {
+                $current[$level] = [];
+                $current = &$current[$level];
+            }
+        }
+
+        $current = $value;
+
+        return $result;
+    }
+}

--- a/tests/Processor/DefaultProcessorTest.php
+++ b/tests/Processor/DefaultProcessorTest.php
@@ -105,7 +105,6 @@ class DefaultProcessorTest extends TestCase
                 'sourceField' => 'price',
                 'transformer' => null
             ]
-
         ]);
     }
 

--- a/tests/Utils/ValuePlacerTest.php
+++ b/tests/Utils/ValuePlacerTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Utils;
+
+use JorisRos\LibraryProductExporter\Utils\ValuePlacer;
+use PHPUnit\Framework\TestCase;
+
+class ValuePlacerTest extends TestCase
+{
+
+
+    public function testStringToMultiArrayWithValue()
+    {
+        $valuePlacer = new ValuePlacer();
+
+        $arrLevels = $valuePlacer->stringToMultiArrayWithValue('product.variants[].price', 'value');
+        $this->assertEquals('value', $arrLevels['product']['variants'][0]['price']);
+
+        $arrLevels = $valuePlacer->stringToMultiArrayWithValue('product.variants[].taxId', 1);
+        $this->assertEquals(1, $arrLevels['product']['variants'][0]['taxId']);
+
+        $arrLevels = $valuePlacer->stringToMultiArrayWithValue('key', 'valvue');
+        $this->assertArrayHasKey(
+            'key',
+            $arrLevels
+        );
+
+        $arrLevels = $valuePlacer->stringToMultiArrayWithValue('level1.level2', 'value');
+        $this->assertArrayHasKey(
+            'level1',
+            $arrLevels
+        );
+
+        $this->assertArrayHasKey(
+            'level2',
+            $arrLevels['level1']
+        );
+        $this->assertEquals('value', $arrLevels['level1']['level2']);
+    }
+}


### PR DESCRIPTION
Because shopify want to have an array for variants where attributes could be placed in